### PR TITLE
Fix pattern for time.Parse, so it doesn't error on 2019-08-16.

### DIFF
--- a/statistics/global_stats.go
+++ b/statistics/global_stats.go
@@ -157,7 +157,7 @@ func yearlyStats(db *gorm.DB) ([]PeriodStats, error) {
 }
 
 func daysSince(dateString string) (int, error) {
-	date, err := time.Parse("2006-02-03", dateString)
+	date, err := time.Parse("2006-01-02", dateString)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
I get the following error using my untappd.json (available at my fork, https://github.com/jsla7527/beers). 

```
chmod +x unparsd
  ./unparsd
  shell: /usr/bin/bash -e {0}
panic: parsing time "2019-08-16": hour out of range

goroutine 1 [running]:
main.main()
	/home/runner/work/unparsd/unparsd/main.go:45 +0x1[3](https://github.com/jsla7527/beers/actions/runs/9056579451/job/24879323037#step:4:3)4
```
After changing the pattern to what I think it should be, unparsd runs fine for the same json. The layout time is specific timestamp, Jan 2, 2006: https://go.dev/src/time/format.go.

Thanks for this great visualizer!